### PR TITLE
Add support for 'count' api methods

### DIFF
--- a/server/common/rest.coffee
+++ b/server/common/rest.coffee
@@ -5,10 +5,17 @@ respondIfOk = (req, res) ->
     res.json 500, 'something went wrong'
 
 routeResource = (name, app, middleware, controller) ->
-  app.get( '/api/' + name,          middleware, controller.index, respondIfOk)
-  app.post('/api/' + name,          middleware, controller.create, respondIfOk)
-  app.put( '/api/' + name + '/:id', middleware, controller.update, respondIfOk)
-  app.get( '/api/' + name + '/:id', middleware, controller.show, respondIfOk)
-  app.del( '/api/' + name + '/:id', middleware, controller.destroy, respondIfOk)
+  app.get( '/api/' + name
+  , middleware, controller.index, respondIfOk)
+  app.post('/api/' + name
+  , middleware, controller.create, respondIfOk)
+  app.get( '/api/' + name + '/count'
+  , middleware, controller.count, respondIfOk)
+  app.put( '/api/' + name + '/:id'
+  , middleware, controller.update, respondIfOk)
+  app.get( '/api/' + name + '/:id'
+  , middleware, controller.show, respondIfOk)
+  app.del( '/api/' + name + '/:id'
+  , middleware, controller.destroy, respondIfOk)
 
 exports.routeResource = routeResource

--- a/server/models/crud.coffee
+++ b/server/models/crud.coffee
@@ -1,4 +1,14 @@
 module.exports = (Resource) ->
+  count = (query, callback) ->
+    if not query.systemId?
+      callback 'Cannot count ' +
+      Resource.modelName + '- no SystemId', null
+    else
+      Resource.count query, (err, count) ->
+        if err
+          callback 'could not count the results', -1
+        else
+          callback null, count
 
   find = (options, callback) ->
     if options?
@@ -105,3 +115,4 @@ module.exports = (Resource) ->
   update: update
   destroy: destroy
   name: Resource.modelName
+  count: count


### PR DESCRIPTION
Essentially, rather than returning the whole json records for a find, calling this method should just return the count

so if www.host.com/resource?name=bob used to return all resources whose name is bob, 

www.host.com/resource/count?name=bob will just return the count
