### PR TITLE
Cart is being stored as json string within json string

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ gi-util
 [![Build Status](https://drone.goincremental.com/github.com/GoIncremental/gi-util/status.svg?branch=master)](https://drone.goincremental.com/github.com/GoIncremental/gi-util)
 
 ### Release Notes
+v1.4.5
+- Fixes issue where items in local storage were double json stringified.
+
 v1.4.4
 - Merge patch for release 1.0.10 (adds support to filter fields in queries)
 

--- a/client/services/localStorage.coffee
+++ b/client/services/localStorage.coffee
@@ -3,9 +3,9 @@ angular.module('gi.util').factory 'giLocalStorage'
 , ($window) ->
   get: (key) ->
     if $window.localStorage[key]
-      cart = angular.fromJson($window.localStorage[key])
-      return JSON.parse(cart)
-    false
+      angular.fromJson($window.localStorage[key])
+    else
+      false
 
   set: (key, val) ->
     if not val?


### PR DESCRIPTION
This Github issue is synchronized with Zendesk,

**Zendesk ticket ID:** [112](https://goincremental.zendesk.com/agent/#/tickets/112)
**Priority:** normal
**Zendesk assignee:** Support/David Bochenski


**Original ticket content:**

The angular local storage service already stringifies the object, so no need to do this in giCart save.
